### PR TITLE
fix: Remove filler from value

### DIFF
--- a/lib/posexional/field.ex
+++ b/lib/posexional/field.ex
@@ -43,14 +43,9 @@ defmodule Posexional.Field do
   end
 
   @spec depositionalize(binary, map) :: binary
-  def depositionalize(content, %Posexional.Field.ProgressiveNumber{filler: filler} = field) do
+  def depositionalize(content, %{filler: filler} = field) do
     content
-    |> nil_if_empty(filler)
     |> remove_filler(field)
-  end
-
-  def depositionalize(content, %{filler: filler}) do
-    content
     |> nil_if_empty(filler)
   end
 

--- a/lib/posexional/field.ex
+++ b/lib/posexional/field.ex
@@ -43,7 +43,7 @@ defmodule Posexional.Field do
   end
 
   @spec depositionalize(binary, map) :: binary
-  def depositionalize(content, %{filler: filler} = field) do
+  def depositionalize(content, field = %{filler: filler}) do
     content
     |> remove_filler(field)
     |> nil_if_empty(filler)

--- a/test/posexional/file_test.exs
+++ b/test/posexional/file_test.exs
@@ -52,7 +52,7 @@ defmodule Posexional.FileTest do
       |> Posexional.FileTest.FileModuleWithGuesser.read()
 
     assert [
-             test: [fixed_value: "te", fixed_value: "st", test_value: "test-", test1: 1, test2: 1],
+             test: [fixed_value: "te", fixed_value: "st", test_value: "test", test1: 1, test2: 1],
              test: [fixed_value: "te", fixed_value: "st", test_value: nil, test1: 2, test2: 2]
            ] === res
   end

--- a/test/posexional/row_test.exs
+++ b/test/posexional/row_test.exs
@@ -24,7 +24,7 @@ defmodule Posexional.RowTest do
 
   test "an unkonwn row do not match" do
     assert [
-             {Posexional.RowTest.RowModule, [fixed_value: "test", a: "A       ", progressive: 1]},
+             {Posexional.RowTest.RowModule, [fixed_value: "test", a: "A", progressive: 1]},
              "nono|A       |00002|-----"
            ] === Posexional.RowTest.FileModule.read("test|A       |00001|-----\nnono|A       |00002|-----")
   end
@@ -35,7 +35,7 @@ defmodule Posexional.RowTest do
 
   test "file module with imported row works" do
     assert [
-             {Posexional.RowTest.OtherRowModule, [fixed_value: "test", a: "A       ", progressive: 1]},
+             {Posexional.RowTest.OtherRowModule, [fixed_value: "test", a: "A", progressive: 1]},
              "nono|A       |00002|-----"
            ] === Posexional.RowTest.OtherFileModule.read("test|A       |00001|-----\nnono|A       |00002|-----")
   end

--- a/test/posexional_test.exs
+++ b/test/posexional_test.exs
@@ -74,7 +74,7 @@ defmodule PosexionalTest do
   test "read a file and outputs a keyword list" do
     row = Row.new(:test, [Field.Value.new(:code, 4, filler: ?0, alignment: :right)], row_guesser: :always)
     file = File.new([row])
-    assert [test: [code: "0001"], test: [code: "0002"]] === Posexional.read(file, "0001\n0002")
+    assert [test: [code: "1"], test: [code: "2"]] === Posexional.read(file, "0001\n0002")
   end
 
   test "read a file and outputs a keyword list with progressive number field" do
@@ -85,7 +85,7 @@ defmodule PosexionalTest do
 
     row = Row.new(:test, fields, row_guesser: :always)
     file = File.new([row])
-    assert [test: [code: "0001", prog: 1], test: [code: "0002", prog: 2]] === Posexional.read(file, "0001001\n0002002")
+    assert [test: [code: "1", prog: 1], test: [code: "2", prog: 2]] === Posexional.read(file, "0001001\n0002002")
   end
 
   test "read a file with a progressive number filled with white spaces and outputs a keyword list with progressive number field" do
@@ -96,7 +96,7 @@ defmodule PosexionalTest do
 
     row = Row.new(:test, fields, row_guesser: :always)
     file = File.new([row])
-    assert [test: [code: "0001", prog: 1], test: [code: "0002", prog: 2]] === Posexional.read(file, "0001  1\n0002  2")
+    assert [test: [code: "1", prog: 1], test: [code: "2", prog: 2]] === Posexional.read(file, "0001  1\n0002  2")
   end
 
   test "read a file with a progressive number filled with white spaces and left aligned and outputs a keyword list with progressive number field" do
@@ -120,7 +120,7 @@ defmodule PosexionalTest do
     row = Row.new(:test, fields, row_guesser: :always)
     file = File.new([row])
 
-    assert [test: [code: "0001", label: "test------"], test: [code: "0002", label: "label-----"]] ===
+    assert [test: [code: "1", label: "test"], test: [code: "2", label: "label"]] ===
              Posexional.read(file, "0001   test------\n0002   label-----")
   end
 


### PR DESCRIPTION
I have noticed that the documented Beatles example is different from the actual implementation. 

The documentation says that the implementation from `BeatlesFile.read()` removes the leading and padding filler, but it actually does not removes it. 

This PR fixes it by removing the filler from the field. 