### PR TITLE
go back to previous behaviour

### DIFF
--- a/lib/posexional/file.ex
+++ b/lib/posexional/file.ex
@@ -59,7 +59,11 @@ defmodule Posexional.File do
   @spec read(%Posexional.File{}, binary) :: [tuple() | String.t()]
   def read(%Posexional.File{separator: separator, rows: rows}, content) do
     content
-    |> String.split(separator, trim: true)
+    |> String.split(separator)
+    |> Enum.filter(fn
+      "" -> false
+      _ -> true
+    end)
     |> Enum.flat_map(fn content ->
       row = guess_row(content, rows)
 


### PR DESCRIPTION
There was an oversight using String.split with trim:true. We go back to the previous behaviour to avoid breaking backwards compatibility.
We should add some tests to avoid regression on this in the future.