### PR TITLE
add  macro to check the field lengths at compile time

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -12,6 +12,7 @@
     separator: 1,
     value: :*,
     field: :*,
+    enforce_length: :*,
 
     # Formatter tests
     assert_format: 2,

--- a/README.md
+++ b/README.md
@@ -151,6 +151,32 @@ This is the output.
 
 Positional files cool again!!! Well no...they still sucks...but a little less.
 
+## Compile time validation
+
+```elixir
+defmodule BeatlesFile do
+  use PosexionalFile
+
+  @separator "\\n"
+
+  row :beatles do # add :always here to always match this row while reading
+    value :name, 5, filler: ?-
+    empty 5
+
+    enforce_length 9 # the actual row length is 10
+  end
+end
+```
+
+In case you'd know the length of the row in advance you can enforce the compiler
+to validate the length. The example above will result in an exception at compile
+time like this: 
+
+```shell
+== Compilation error in file test/posexional/beatles.exs ==
+** (RuntimeError) The length of the row (10) doens't match the expetation (9)
+```
+
 <!--MDOC !-->
 
 ## Contributing

--- a/lib/posexional_row.ex
+++ b/lib/posexional_row.ex
@@ -136,7 +136,8 @@ defmodule PosexionalRow do
         |> Enum.map(fn x -> FieldLength.length(x) end)
         |> Enum.sum()
 
-      if s != unquote(count), do: raise("The length of the row (#{s}) doesn't match the expectation (#{unquote(count)})")
+      if s != unquote(count),
+        do: raise("The length of the row (#{s}) doesn't match the expectation (#{unquote(count)})")
     end
   end
 end

--- a/lib/posexional_row.ex
+++ b/lib/posexional_row.ex
@@ -4,6 +4,7 @@ defmodule PosexionalRow do
   """
 
   alias Posexional.Field
+  alias Posexional.Protocol.FieldLength
 
   @doc """
   add use Posexional on top of an elixir module to use macros to define fields
@@ -121,6 +122,21 @@ defmodule PosexionalRow do
   defmacro field(field_name, type, size, opts \\ []) do
     quote do
       @fields Field.TypedField.new(unquote(field_name), unquote(type), unquote(size), unquote(opts))
+    end
+  end
+
+  @doc """
+  enforce the row fields length sum to be equal to count. Raise an exception at
+  compile time otherwise. It's useful when you know the row length in advance.
+  """
+  defmacro enforce_length(count) do
+    quote do
+      s =
+        @fields
+        |> Enum.map(fn x -> FieldLength.length(x) end)
+        |> Enum.sum()
+
+      if s != unquote(count), do: raise("The length of the row (#{s}) doens't match the expetation (#{unquote(count)})")
     end
   end
 end

--- a/lib/posexional_row.ex
+++ b/lib/posexional_row.ex
@@ -136,7 +136,7 @@ defmodule PosexionalRow do
         |> Enum.map(fn x -> FieldLength.length(x) end)
         |> Enum.sum()
 
-      if s != unquote(count), do: raise("The length of the row (#{s}) doens't match the expetation (#{unquote(count)})")
+      if s != unquote(count), do: raise("The length of the row (#{s}) doesn't match the expectation (#{unquote(count)})")
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Posexional.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/primait/posexional"
-  @version "1.1.1"
+  @version "1.2.1"
 
   def project do
     [

--- a/test/posexional/file_test.exs
+++ b/test/posexional/file_test.exs
@@ -12,6 +12,8 @@ defmodule Posexional.FileTest do
       value :test_value, 5, filler: ?-
       progressive_number :test1, 3, filler: ?0
       progressive_number :test2, 3, filler: ?0
+
+      enforce_length 15
     end
   end
 

--- a/test/posexional/row_test.exs
+++ b/test/posexional/row_test.exs
@@ -18,6 +18,8 @@ defmodule Posexional.RowTest do
 
     def matcher(<<"test", _::binary>>), do: true
     def matcher(_), do: false
+
+    enforce_length(4 + 8 + 5 + 5)
   end
 
   defmodule FileModule do


### PR DESCRIPTION
This pr is related to [issue](https://github.com/primait/posexional/issues/68)