### PR TITLE
chore: bump to 1.2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Posexional.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/primait/posexional"
-  @version "1.2.1"
+  @version "1.2.0"
 
   def project do
     [


### PR DESCRIPTION
I can't release `1.2.0`, we made a typo on the version number and that's breaking the release job https://github.com/primait/posexional/actions/runs/15446280199/job/43476757659